### PR TITLE
patch for using cryptsetup instead of losetup.crypto

### DIFF
--- a/make_uird_magos.sh
+++ b/make_uird_magos.sh
@@ -4,7 +4,7 @@ cd dracut/modules.d
 ln -s ../../modules.d/* ../modules.d/ 2>/dev/null
 cd ../..
 filesystems="aufs squashfs vfat msdos iso9660 isofs xfs fuse nfs cifs udf nls_cp866 nls_utf8 reiserfs overlay ext3 ntfs"
-kernelmods="loop cryptoloop cbc zram aes-generic aes-i586 aes-x86_64 pata_acpi ata_generic ahci xhci-hcd xhci-pci xhci-plat-hcd ohci-pci  usb-storage uhci-hcd hid usbhid ehci-hcd ohci-hcd ehci-pci ehci-platform hid-generic sr_mod sd_mod scsi_mod jbd jbd2 lockd evdev sunrpc lz4 af_packet"
+kernelmods="loop cryptoloop cbc zram aes-generic aes-i586 aes-x86_64 pata_acpi ata_generic ahci xhci-hcd xhci-pci xhci-plat-hcd ohci-pci  usb-storage uhci-hcd hid usbhid ehci-hcd ohci-hcd ehci-pci ehci-platform hid-generic sr_mod sd_mod scsi_mod jbd jbd2 lockd evdev sunrpc lz4 af_packet dm-crypt"
 
 FS=''
 for mod in $filesystems ; do

--- a/modules.d/00uird/livekit/livekitlib
+++ b/modules.d/00uird/livekit/livekitlib
@@ -787,7 +787,7 @@ mount_device()
        while [ $times -gt 0 ]; do
           read -s -pPassword: >/dev/console </dev/console 2>/dev/console ; echo $REPLY | cryptsetup open --type loopaes "$DEV" "$LOOPDEV" --key-file -
           mount -n -o ro "/dev/mapper/$LOOPDEV" "$2" >>/var/log/uird.dbg.log 2>&1
-          ERR=$?
+          ERR=$? ; REPLY=
           if [ $ERR -ne 0 ]; then
              echo incorrect! >/dev/console
              cryptsetup close "$LOOPDEV"

--- a/modules.d/00uird/livekit/livekitlib
+++ b/modules.d/00uird/livekit/livekitlib
@@ -42,7 +42,6 @@ BIN_FSCK=/sbin/fsck
 BIN_BTRFSCK=/sbin/btrfsck
 BIN_BLKID=/sbin/blkid.real
 BIN_LOSETUP=/sbin/losetup.real
-BIN_LOSETUP_CRYPTO=/sbin/losetup.crypto
 
 [ -f /etc/initvars ] && . /etc/initvars
 
@@ -778,21 +777,29 @@ mount_device()
     fi
 
     if [ $ERR -ne 0 ] && [ -f "$DEV" ] && echo "$DEV" | grep -q .enc$ ; then
-    	modprobe cryptoloop
-        LOOPDEV=$(losetup -f)
-        [ -z "$LOOPDEV" ] && LOOPDEV=$(mknod_next_loop_dev)
-        OPTIONS=$(echo "$OPTIONS" | sed -r "s/,loop//g")
-        echolog "$MOUNT_DEVICE_ENC" $green"$DEV"$default
-        times=3
-        while [ $times -gt 0 ]; do
-            $BIN_LOSETUP_CRYPTO -e AES256 "$LOOPDEV" "$DEV" >/dev/console </dev/console 2>/dev/console
-            [ $(cmdline_parameter fsck) ] && fsck_device "$LOOPDEV"
-            mount -n -o $OPTIONS "$LOOPDEV" "$2" >>/var/log/uird.dbg.log 2>&1
-            ERR=$?
-            [ $ERR -eq 0 ] && break
-            $BIN_LOSETUP_CRYPTO -d "$LOOPDEV"
-            times=$(expr $times - 1)
-        done
+       echolog "$MOUNT_DEVICE_ENC" $green"$DEV"$default
+       OPTIONS=$(echo "$OPTIONS" | sed -r "s/,loop//g")
+       for a in $(seq 0 254) ;do
+          [ -f /dev/mapper/uirdencdev$a -o -b /dev/mapper/uirdencdev$a ] && continue
+          LOOPDEV=uirdencdev$a ;break
+       done
+       times=3
+       while [ $times -gt 0 ]; do
+          read -s -pPassword: >/dev/console </dev/console 2>/dev/console ; echo $REPLY | cryptsetup open --type loopaes "$DEV" "$LOOPDEV" --key-file -
+          mount -n -o ro "/dev/mapper/$LOOPDEV" "$2" >>/var/log/uird.dbg.log 2>&1
+          ERR=$?
+          if [ $ERR -ne 0 ]; then
+             echo incorrect! >/dev/console
+             cryptsetup close "$LOOPDEV"
+             times=$(expr $times - 1)
+          else
+             echo accepted! >/dev/console
+             umount "$2"
+             [ $(cmdline_parameter fsck) ] && fsck_device "/dev/mapper/$LOOPDEV"
+             mount -n -o $OPTIONS "/dev/mapper/$LOOPDEV" "$2" >>/var/log/uird.dbg.log 2>&1
+             break
+          fi
+       done
     fi
 
     # not enough loop devices? try to create one.

--- a/modules.d/00uird/module-setup.sh
+++ b/modules.d/00uird/module-setup.sh
@@ -15,7 +15,7 @@ installkernel() {
     return 0
 }
 
-bins="locale dialog gettext loadkeys resume rsync fsck fsck.ext2 fsck.ext3 fsck.ext4 fsck.exfat fsck.vfat fsck.xfs fsck.btrfs btrfsck ntfsfix"
+bins="locale dialog gettext loadkeys resume rsync fsck fsck.ext2 fsck.ext3 fsck.ext4 fsck.exfat fsck.vfat fsck.xfs fsck.btrfs btrfsck ntfsfix cryptsetup"
 
 install() {
     local _i _progs _path _busybox _binaries
@@ -31,8 +31,6 @@ install() {
     [ -x "$initdir/bin/bash" ] || inst $(type -p bash) "/bin/bash"
     inst $(type -p blkid) /sbin/blkid.real
     inst $(type -p losetup) /sbin/losetup.real
-    [ "$(uname -i)" = "x86_64" -a -x /usr/lib/magos/bin64/losetup ] && inst $(type -p /usr/lib/magos/bin64/losetup ) /sbin/losetup.crypto
-    [ "$(uname -i)" != "x86_64" -a -x /usr/lib/magos/bin/losetup  ] && inst $(type -p /usr/lib/magos/bin/losetup )   /sbin/losetup.crypto
 
     _binaries=""
     for bin in  $bins ; do


### PR DESCRIPTION
внес изменения для ядра 4.9, но это не финальный вариант, cryptsetup не работает из-за udev, надо с этим разбираться, что с ним не так